### PR TITLE
Add CLI entry for servo demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # pi5-mg90s-tools
-树莓派 Pi5的舵机mg90s的使用
+
+树莓派 Pi5 的舵机 MG90S 的使用
+
+## 示例
+
+示例脚本位于 `examples/` 目录。运行前需安装 `gpiozero` 及 `lgpio`:
+
+```bash
+sudo apt install python3-gpiozero python3-lgpio
+```
+
+执行：
+
+```bash
+python3 examples/main.py --pin 18
+```
+
+`--pin` 指定舵机连接的 BCM 引脚，默认为 18。脚本会循环将舵机从最小角度移动到最大角度。
+
+## 许可
+
+本项目采用 MIT 许可协议。

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,0 +1,14 @@
+import argparse
+from servo_control import sweep
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MG90S servo demo")
+    parser.add_argument("--pin", type=int, default=18,
+                        help="BCM GPIO pin connected to the servo")
+    args = parser.parse_args()
+    sweep(args.pin)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/servo_control.py
+++ b/examples/servo_control.py
@@ -1,0 +1,19 @@
+from gpiozero import Servo, Device
+from gpiozero.pins.lgpio import LGPIOFactory
+from time import sleep
+
+Device.pin_factory = LGPIOFactory()
+
+
+def sweep(pin, positions=None):
+    """Sweep servo connected to specified BCM pin through positions."""
+    servo = Servo(pin)
+    if positions is None:
+        positions = [-1, -0.5, 0, 0.5, 1]
+    try:
+        while True:
+            for pos in positions:
+                servo.value = pos
+                sleep(1)
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
- rename example to `servo_control.py` using lgpio backend
- add `main.py` to select the GPIO pin with `--pin`
- update README with usage instructions

## Testing
- `python3 -m py_compile examples/servo_control.py examples/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6881dcc80868833180bed2504b395eb4